### PR TITLE
Add CLI as an example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,10 @@ license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[example]]
+name = "cli"
+
 [dependencies]
+
+[dev-dependencies]
+clap = "2.33.0"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This project implements a client library for the telemetry data that is
 published by the current generation of [F1 video games][f1] by [Codemasters].
 The library is written in Rust, using [tokio] for async networking.
 
+## Examples
+
+The `examples` folder contains examples that show how to use this library. They
+can also be helpful for local development, in particular the `cli` example. It
+uses the library to listen to telemetry packages from an F1 game, and prints
+them on the terminal. More information how to use the CLI can be gathered from
+the following command:
+
+    cargo run --example cli -- --help
+
 ## License
 
 Licensed under either of

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,0 +1,5 @@
+use clap::{crate_version, App};
+
+fn main() {
+    App::new("F1 API").version(crate_version!()).get_matches();
+}


### PR DESCRIPTION
Having a CLI to quickly test changes to the library makes development a
lot easier. After considering creating a workspace for the library and a
CLI binary, the decision was made to use an example instead. The binary
will never be used outside the scope of the library, so having a
separate crate feels like overkill.