### PR TITLE
Create stream that returns incoming packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ name = "cli"
 [dependencies]
 bitflags = "1.2.1"
 bytes = "0.5.4"
-tokio-util = { version = "0.3.0", features = ["codec"] }
+net2 = "0.2.33"
+tokio = { version = "0.2.13", features = ["macros", "net", "stream", "udp"] }
+tokio-util = { version = "0.3.0", features = ["codec", "udp"] }
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,5 +1,53 @@
-use clap::{crate_version, App};
+use clap::{crate_version, App, Arg};
+use f1_api::nineteen::Packet;
+use f1_api::packet::Packet::Nineteen;
+use f1_api::F1;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use tokio::stream::StreamExt;
 
-fn main() {
-    App::new("F1 API").version(crate_version!()).get_matches();
+#[tokio::main]
+async fn main() {
+    let matches = App::new("F1 API")
+        .version(crate_version!())
+        .arg(
+            Arg::with_name("address")
+                .short("a")
+                .long("address")
+                .value_name("IP ADDRESS")
+                .help("IP address to bind the local socket to")
+                .default_value("0.0.0.0")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("port")
+                .short("p")
+                .long("port")
+                .value_name("PORT")
+                .help("Port to bind the local socket to")
+                .default_value("20777")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let ip_address = matches.value_of("address").unwrap();
+    let port: u16 = matches.value_of("port").unwrap().parse().unwrap();
+
+    let socket = SocketAddr::new(IpAddr::from_str(ip_address).unwrap(), port);
+    let mut stream = F1::stream(socket).unwrap();
+
+    while let Some(packet) = stream.next().await {
+        match packet {
+            Nineteen(packet) => match packet {
+                Packet::Event(_) => println!("Received Event packet"),
+                Packet::Lap(_) => println!("Received Lap packet"),
+                Packet::Motion(_) => println!("Received Motion packet"),
+                Packet::Participants(_) => println!("Received Participants packet"),
+                Packet::Session(_) => println!("Received Session packet"),
+                Packet::Setup(_) => println!("Received Setup packet"),
+                Packet::Telemetry(_) => println!("Received Telemetry packet"),
+                Packet::Status(_) => println!("Received Status packet"),
+            },
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,14 @@
 //! A Rust implementation of the telemetry API provided by modern F1 video games
 
+use crate::codec::F1Codec;
+use crate::packet::Packet;
+use net2::UdpBuilder;
+use std::io::Error;
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+use tokio::stream::{Stream, StreamExt};
+use tokio_util::udp::UdpFramed;
+
 pub mod codec;
 pub mod nineteen;
 pub mod packet;
@@ -10,8 +19,45 @@ pub mod packet;
 /// modern F1 video games. It is the recommended way to use the library, as it
 /// provides a simple interface to consumers that hides the low-level internals
 /// of the library.
-///
-/// TODO Add usage example
 pub struct F1 {}
 
-impl F1 {}
+impl F1 {
+    /// Create a stream that yields decoded UDP packets.
+    ///
+    /// Modern F1 games publish their telemetry and session data through a UDP-based protocol. With
+    /// this function, a stream can be created that listens at the given socket for incoming
+    /// packets, decodes them using the `F1Codec`, and returns their Rust representations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use f1_api::F1;
+    /// use f1_api::packet::Packet::Nineteen;
+    /// use std::net::{IpAddr, SocketAddr};
+    /// use tokio::stream::StreamExt;
+    ///
+    /// async fn example() {
+    ///     let ip_address = IpAddr::from([0, 0, 0, 0]);
+    ///     let port = 20777;
+    ///     let socket = SocketAddr::new(ip_address, port);
+    ///
+    ///     let mut stream = F1::stream(socket).unwrap();
+    ///
+    ///     while let Some(packet) = stream.next().await {
+    ///         match packet {
+    ///             Nineteen(packet) => println!("Received a packet from F1 2019")
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    pub fn stream(socket_address: SocketAddr) -> Result<impl Stream<Item = Packet>, Error> {
+        let socket = match socket_address {
+            SocketAddr::V4(address) => UdpBuilder::new_v4()?.bind(address),
+            SocketAddr::V6(address) => UdpBuilder::new_v6()?.only_v6(true)?.bind(address),
+        }?;
+
+        Ok(UdpFramed::new(UdpSocket::from_std(socket)?, F1Codec)
+            .map(|result| result.unwrap())
+            .map(|(packet, _address)| packet))
+    }
+}


### PR DESCRIPTION
A function has been added that creates a stream that listens for
incoming UDP packets, decodes them into Rust structs, and returns them
asynchronously.