### PR TITLE
Update Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ name = "readme"
 
 [dependencies]
 bitflags = "1.2.1"
-bytes = "0.5.4"
+bytes = "1.0.1"
 derive-new = "0.5.8"
 getset = "0.1.0"
 net2 = "0.2.33"
-tokio = { version = "0.2.13", features = ["macros", "net", "stream", "udp"] }
-tokio-util = { version = "0.3.0", features = ["codec", "udp"] }
+tokio = { version = "1.7.1", features = ["macros", "net", "rt-multi-thread"] }
+tokio-stream = "0.1.6"
+tokio-util = { version = "0.6.7", features = ["codec", "net"] }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ the packets that the F1 games sent. The only piece users need to interact with
 is the `F1` struct and its high-level interface.
 
 ```rust
+use std::net::{IpAddr, SocketAddr};
+
 use f1_api::F1;
 use f1_api::packet::Packet::{
     Event, Lap, Motion, Participants, Session, Setup, Status, Telemetry
 };
-use std::net::{IpAddr, SocketAddr};
-use tokio::stream::StreamExt;
+use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() {

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,9 +1,11 @@
-use clap::{crate_version, App, Arg};
-use f1_api::packet::Packet::{Event, Lap, Motion, Participants, Session, Setup, Status, Telemetry};
-use f1_api::F1;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
-use tokio::stream::StreamExt;
+
+use clap::{crate_version, App, Arg};
+use tokio_stream::StreamExt;
+
+use f1_api::packet::Packet::{Event, Lap, Motion, Participants, Session, Setup, Status, Telemetry};
+use f1_api::F1;
 
 #[tokio::main]
 async fn main() {

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,7 +1,9 @@
+use std::net::{IpAddr, SocketAddr};
+
+use tokio_stream::StreamExt;
+
 use f1_api::packet::Packet::{Event, Lap, Motion, Participants, Session, Setup, Status, Telemetry};
 use f1_api::F1;
-use std::net::{IpAddr, SocketAddr};
-use tokio::stream::StreamExt;
 
 #[tokio::main]
 async fn main() {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,10 +1,12 @@
 //! Codec for modern F1 games
 
+use std::io::{Cursor, Error, ErrorKind};
+
+use bytes::{Buf, BytesMut};
+use tokio_util::codec::Decoder;
+
 use crate::nineteen::decode_nineteen;
 use crate::packet::Packet;
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
-use tokio_util::codec::Decoder;
 
 /// Codec to decode UDP packets published by modern F1 games.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,15 @@
 //! A Rust implementation of the telemetry API provided by modern F1 video games
 
-use crate::codec::F1Codec;
-use crate::packet::Packet;
-use net2::UdpBuilder;
 use std::io::Error;
 use std::net::SocketAddr;
+
+use net2::UdpBuilder;
 use tokio::net::UdpSocket;
-use tokio::stream::{Stream, StreamExt};
+use tokio_stream::{Stream, StreamExt};
 use tokio_util::udp::UdpFramed;
+
+use crate::codec::F1Codec;
+use crate::packet::Packet;
 
 pub mod codec;
 pub mod nineteen;
@@ -32,10 +34,11 @@ impl F1 {
     /// # Examples
     ///
     /// ```
+    /// use std::net::{IpAddr, SocketAddr};
+    ///
     /// use f1_api::F1;
     /// use f1_api::packet::Packet::{Event, Lap, Motion, Participants, Session, Setup, Status, Telemetry};
-    /// use std::net::{IpAddr, SocketAddr};
-    /// use tokio::stream::StreamExt;
+    /// use tokio_stream::StreamExt;
     ///
     /// async fn example() {
     ///     let ip_address = IpAddr::from([0, 0, 0, 0]);

--- a/src/nineteen.rs
+++ b/src/nineteen.rs
@@ -7,6 +7,10 @@
 //! The full API specification can be found here:
 //! https://forums.codemasters.com/topic/44592-f1-2019-udp-specification/
 
+use std::io::{Cursor, Error};
+
+use bytes::BytesMut;
+
 use crate::nineteen::event::decode_event;
 use crate::nineteen::header::decode_header;
 use crate::nineteen::lap::decode_lap_data;
@@ -18,8 +22,6 @@ use crate::nineteen::status::decode_statuses;
 use crate::nineteen::telemetry::decode_telemetry;
 use crate::packet::header::PacketType;
 use crate::packet::Packet;
-use bytes::BytesMut;
-use std::io::{Cursor, Error};
 
 mod header;
 

--- a/src/nineteen/event.rs
+++ b/src/nineteen/event.rs
@@ -3,14 +3,16 @@
 //! F1 2019 extended the event packet with seven new events compared to its predecessor, four of
 //! which can carry a payload.
 
+use std::io::{Cursor, Error, ErrorKind};
+use std::time::Duration;
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::event::{
     Event, EventPacket, FastestLap, RaceWinner, Retirement, TeammateInPits,
 };
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
-use std::time::Duration;
 
 /// Size of the event packet in bytes
 ///
@@ -91,10 +93,12 @@ fn decode_race_winner(cursor: &mut Cursor<&mut BytesMut>) -> Event {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use bytes::{BufMut, BytesMut};
+
     use crate::nineteen::event::{decode_event, PACKET_SIZE};
     use crate::packet::event::Event;
-    use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/flag.rs
+++ b/src/nineteen/flag.rs
@@ -1,8 +1,10 @@
 //! Decoder for flags that can be shown to cars
 
-use crate::types::Flag;
-use bytes::{Buf, BytesMut};
 use std::io::{Cursor, Error, ErrorKind};
+
+use bytes::{Buf, BytesMut};
+
+use crate::types::Flag;
 
 /// Decode a flag that can be shown to cars
 pub fn decode_flag(cursor: &mut Cursor<&mut BytesMut>) -> Result<Flag, Error> {

--- a/src/nineteen/header.rs
+++ b/src/nineteen/header.rs
@@ -1,10 +1,12 @@
 //! Decoder for header prefixing packets sent by F1 2019
 
-use crate::packet::ensure_packet_size;
-use crate::packet::header::{ApiSpec, GameVersion, Header, PacketType};
+use std::io::{Cursor, Error, ErrorKind};
+
 use bitflags::_core::time::Duration;
 use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
+
+use crate::packet::ensure_packet_size;
+use crate::packet::header::{ApiSpec, GameVersion, Header, PacketType};
 
 /// Size of the packet header in F1 2019
 pub const HEADER_SIZE: usize = 23;
@@ -77,10 +79,12 @@ fn decode_packet_type(cursor: &mut Cursor<&mut BytesMut>) -> Result<PacketType, 
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use bytes::{BufMut, BytesMut};
+
     use crate::nineteen::header::{decode_header, HEADER_SIZE};
     use crate::packet::header::{ApiSpec, PacketType};
-    use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
 
     #[test]
     fn decode_header_with_error() {

--- a/src/nineteen/lap.rs
+++ b/src/nineteen/lap.rs
@@ -3,12 +3,14 @@
 //! The lap data packets by F1 2018 and F1 2019 differ only in their packet headers, the rest of the
 //! packet format is identical.
 
+use std::io::{Cursor, Error, ErrorKind};
+use std::time::Duration;
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::lap::{DriverStatus, Lap, LapPacket, PitStatus, ResultStatus, Sector};
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
-use std::time::Duration;
 
 /// Size of the lap data packet in bytes
 pub const PACKET_SIZE: usize = 843;
@@ -112,10 +114,12 @@ fn decode_result_status(cursor: &mut Cursor<&mut BytesMut>) -> Result<ResultStat
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use bytes::{BufMut, BytesMut};
+
     use crate::nineteen::lap::{decode_lap_data, PACKET_SIZE};
     use crate::packet::lap::{DriverStatus, PitStatus, ResultStatus, Sector};
-    use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/motion.rs
+++ b/src/nineteen/motion.rs
@@ -3,12 +3,14 @@
 //! The motion packets by F1 2018 and F1 2019 differ only in their packet headers, the rest of the
 //! packet format is identical.
 
+use std::io::{Cursor, Error};
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::motion::{Motion, MotionPacket};
 use crate::types::{CornerProperty, Property3D};
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error};
 
 /// Size of the motion packet in bytes
 pub const PACKET_SIZE: usize = 1343;
@@ -174,10 +176,12 @@ fn decode_angular_acceleration(cursor: &mut Cursor<&mut BytesMut>) -> Property3D
 
 #[cfg(test)]
 mod tests {
-    use crate::nineteen::motion::{decode_motion, PACKET_SIZE};
+    use std::io::Cursor;
+
     use assert_approx_eq::assert_approx_eq;
     use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
+
+    use crate::nineteen::motion::{decode_motion, PACKET_SIZE};
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/participants.rs
+++ b/src/nineteen/participants.rs
@@ -3,13 +3,15 @@
 //! F1 2019 extends the participants packet from F1 2018 with the `telemetry_privacy` field. Other
 //! than that both games use the same packet format.
 
+use std::io::{Cursor, Error, ErrorKind};
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::participants::{
     Controller, Driver, Nationality, Participant, ParticipantsPacket, Team, TelemetryPrivacy,
 };
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
 
 /// Size of the participants packet.
 pub const PACKET_SIZE: usize = 1104;
@@ -341,10 +343,12 @@ fn decode_telemetry_privacy(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use bytes::{BufMut, BytesMut};
+
     use crate::nineteen::participants::{decode_name, decode_participants, PACKET_SIZE};
     use crate::packet::participants::{Controller, Driver, Nationality, Team, TelemetryPrivacy};
-    use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/session.rs
+++ b/src/nineteen/session.rs
@@ -3,15 +3,17 @@
 //! The session packets by F1 2018 and F1 2019 differ only in their packet headers, the rest of the
 //! packet format is identical.
 
+use std::io::{Cursor, Error, ErrorKind};
+use std::time::Duration;
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::flag::decode_flag;
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::session::{
     Formula, MarshalZone, SafetyCar, Session, SessionPacket, Track, Weather,
 };
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
-use std::time::Duration;
 
 /// Size of the session packet in F1 2019
 pub const PACKET_SIZE: usize = 149;
@@ -183,10 +185,12 @@ fn decode_safety_car(cursor: &mut Cursor<&mut BytesMut>) -> Result<SafetyCar, Er
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use bytes::{BufMut, BytesMut};
+
     use crate::nineteen::session::{decode_session, PACKET_SIZE};
     use crate::packet::session::{Formula, SafetyCar, Session, Track, Weather};
-    use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/setup.rs
+++ b/src/nineteen/setup.rs
@@ -3,11 +3,13 @@
 //! The car setup packets by F1 2018 and F1 2019 differ only in their packet headers, the rest of
 //! the packet format is identical.
 
+use std::io::{Cursor, Error};
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::setup::{CarSetup, CarSetupPacket};
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error};
 
 /// Size of the car setups packet in bytes
 pub const PACKET_SIZE: usize = 843;
@@ -52,10 +54,12 @@ pub fn decode_setups(cursor: &mut Cursor<&mut BytesMut>) -> Result<CarSetupPacke
 
 #[cfg(test)]
 mod tests {
-    use crate::nineteen::setup::{decode_setups, PACKET_SIZE};
+    use std::io::Cursor;
+
     use assert_approx_eq::assert_approx_eq;
     use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
+
+    use crate::nineteen::setup::{decode_setups, PACKET_SIZE};
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/status.rs
+++ b/src/nineteen/status.rs
@@ -4,6 +4,10 @@
 //! visual tyre compound (e.g. hard). This makes it packet format and decoder incompatible with
 //! earlier F1 games.
 
+use std::io::{Cursor, Error, ErrorKind};
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::flag::decode_flag;
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
@@ -12,8 +16,6 @@ use crate::packet::status::{
     TractionControl, VisualTyreCompound,
 };
 use crate::types::CornerProperty;
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
 
 /// Size of the car status packet in bytes
 pub const PACKET_SIZE: usize = 1143;
@@ -195,15 +197,17 @@ fn decode_ers_deploy_mode(cursor: &mut Cursor<&mut BytesMut>) -> Result<ErsDeplo
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
+    use assert_approx_eq::assert_approx_eq;
+    use bytes::{BufMut, BytesMut};
+
     use crate::nineteen::status::{decode_statuses, PACKET_SIZE};
     use crate::packet::status::{
         DrsSetting, ErsDeployMode, FuelMix, PhysicalTyreCompound, TractionControl,
         VisualTyreCompound,
     };
     use crate::types::Flag;
-    use assert_approx_eq::assert_approx_eq;
-    use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/nineteen/telemetry.rs
+++ b/src/nineteen/telemetry.rs
@@ -3,12 +3,14 @@
 //! The telemetry packets by F1 2018 and F1 2019 differ only in their packet headers, the rest of
 //! the packet format is identical.
 
+use std::io::{Cursor, Error, ErrorKind};
+
+use bytes::{Buf, BytesMut};
+
 use crate::nineteen::header::decode_header;
 use crate::packet::ensure_packet_size;
 use crate::packet::telemetry::{Button, Gear, Surface, Telemetry, TelemetryPacket};
 use crate::types::CornerProperty;
-use bytes::{Buf, BytesMut};
-use std::io::{Cursor, Error, ErrorKind};
 
 /// Size of the telemetry packet in bytes
 pub const PACKET_SIZE: usize = 1347;
@@ -141,11 +143,13 @@ fn decode_surface(cursor: &mut Cursor<&mut BytesMut>) -> Result<Surface, Error> 
 
 #[cfg(test)]
 mod tests {
-    use crate::nineteen::telemetry::{decode_telemetry, PACKET_SIZE};
-    use crate::packet::telemetry::{Button, Gear, Surface};
+    use std::io::Cursor;
+
     use assert_approx_eq::assert_approx_eq;
     use bytes::{BufMut, BytesMut};
-    use std::io::Cursor;
+
+    use crate::nineteen::telemetry::{decode_telemetry, PACKET_SIZE};
+    use crate::packet::telemetry::{Button, Gear, Surface};
 
     fn put_packet_header(mut bytes: BytesMut) -> BytesMut {
         bytes.put_u16_le(2019);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -4,8 +4,9 @@
 //! specification has been slowly evolving from game to game, but without such significant changes
 //! that it would require a different packet format.
 
-use bytes::{Buf, BytesMut};
 use std::io::{Cursor, Error, ErrorKind};
+
+use bytes::{Buf, BytesMut};
 
 pub mod event;
 pub mod header;
@@ -85,9 +86,11 @@ pub(crate) fn ensure_packet_size(
 
 #[cfg(test)]
 mod tests {
-    use crate::packet::ensure_packet_size;
-    use bytes::{Buf, BufMut, BytesMut};
     use std::io::{Cursor, Error};
+
+    use bytes::{Buf, BufMut, BytesMut};
+
+    use crate::packet::ensure_packet_size;
 
     struct Packet {
         counter: u8,

--- a/src/packet/event.rs
+++ b/src/packet/event.rs
@@ -4,13 +4,15 @@
 //! only two events, but _F1 2019_ extended this to nine different events. Some events carry a
 //! payload that further defines the event, and that are declared in this module as structs.
 
-use crate::packet::header::Header;
-use crate::types::VehicleIndex;
-use derive_new::new;
-use getset::{CopyGetters, Getters};
 use std::fmt;
 use std::fmt::Display;
 use std::time::Duration;
+
+use derive_new::new;
+use getset::{CopyGetters, Getters};
+
+use crate::packet::header::Header;
+use crate::types::VehicleIndex;
 
 /// Payload for fastest lap event
 ///

--- a/src/packet/header.rs
+++ b/src/packet/header.rs
@@ -1,11 +1,13 @@
 //! Header prefixing packets from modern F1 games
 
-use crate::types::VehicleIndex;
-use derive_new::new;
-use getset::{CopyGetters, Getters};
 use std::fmt;
 use std::fmt::Display;
 use std::time::Duration;
+
+use derive_new::new;
+use getset::{CopyGetters, Getters};
+
+use crate::types::VehicleIndex;
 
 /// Supported API specifications
 ///

--- a/src/packet/lap.rs
+++ b/src/packet/lap.rs
@@ -4,10 +4,12 @@
 //! which the packets are sent can be configured in the game. F1 2018 and F1 2019 share the same
 //! packet format.
 
-use crate::packet::header::Header;
+use std::time::Duration;
+
 use derive_new::new;
 use getset::{CopyGetters, Getters};
-use std::time::Duration;
+
+use crate::packet::header::Header;
 
 /// Statuses a driver can have during a lap
 #[derive(Debug, PartialEq, Copy, Clone, Eq, Ord, PartialOrd, Hash)]

--- a/src/packet/motion.rs
+++ b/src/packet/motion.rs
@@ -4,10 +4,11 @@
 //! motion packet. The rate with which these packets are sent can be configured in the game. F1 2018
 //! and F1 2019 publish the same motion data.
 
-use crate::packet::header::Header;
-use crate::types::{CornerProperty, Property3D};
 use derive_new::new;
 use getset::{CopyGetters, Getters};
+
+use crate::packet::header::Header;
+use crate::types::{CornerProperty, Property3D};
 
 /// Data about a car and its position and movement in space
 ///

--- a/src/packet/participants.rs
+++ b/src/packet/participants.rs
@@ -304,7 +304,9 @@ impl Default for TelemetryPrivacy {
 ///
 /// The F1 games publish data for each participant in a session that identifies them. This data
 /// includes the participant's name, team, and nationality among others.
-#[derive(new, Debug, CopyGetters, Getters, PartialEq, Clone, Eq, Ord, PartialOrd, Hash, Default)]
+#[derive(
+    new, Debug, CopyGetters, Getters, PartialEq, Clone, Eq, Ord, PartialOrd, Hash, Default,
+)]
 pub struct Participant {
     /// Returns the type of controller.
     #[getset(get_copy = "pub")]

--- a/src/packet/session.rs
+++ b/src/packet/session.rs
@@ -3,11 +3,13 @@
 //! The F1 games provide information about the current session, for example weather and temperature
 //! as well as settings like the type of safety car in use.
 
-use crate::packet::header::Header;
-use crate::types::{Flag, VehicleIndex};
+use std::time::Duration;
+
 use derive_new::new;
 use getset::{CopyGetters, Getters};
-use std::time::Duration;
+
+use crate::packet::header::Header;
+use crate::types::{Flag, VehicleIndex};
 
 /// Types of formula racing supported by the F1 games
 ///

--- a/src/packet/setup.rs
+++ b/src/packet/setup.rs
@@ -3,9 +3,10 @@
 //! The F1 games publish data about the setups of all cars in a session. In multiplayer sessions,
 //! setups of other players are redacted to prevent anyone from gaining an unfair advantage.
 
-use crate::packet::header::Header;
 use derive_new::new;
 use getset::{CopyGetters, Getters};
+
+use crate::packet::header::Header;
 
 /// Setup of a car
 ///

--- a/src/packet/status.rs
+++ b/src/packet/status.rs
@@ -3,10 +3,11 @@
 //! The F1 games provide detailed information about the status of each car in the session. The rate
 //! with which the data is provided can be configured in the in-game settings.
 
-use crate::packet::header::Header;
-use crate::types::{CornerProperty, Flag};
 use derive_new::new;
 use getset::{CopyGetters, Getters};
+
+use crate::packet::header::Header;
+use crate::types::{CornerProperty, Flag};
 
 /// Traction control settings
 ///

--- a/src/packet/telemetry.rs
+++ b/src/packet/telemetry.rs
@@ -4,11 +4,12 @@
 //! includes physical properties of the car, e.g. its speed, but also information about the controls
 //! that are applied, e.g. which buttons are being pressed.
 
-use crate::packet::header::Header;
-use crate::types::CornerProperty;
 use bitflags::bitflags;
 use derive_new::new;
 use getset::{CopyGetters, Getters};
+
+use crate::packet::header::Header;
+use crate::types::CornerProperty;
 
 bitflags! {
     /// A bit field with currently pressed buttons.


### PR DESCRIPTION
Since this crate was last released, tokio has been upgraded to 1.0. This
version changed some APIs, which required some manual changes to bump
its version.