### PR TITLE
Deprecate net2 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bitflags = "1.2.1"
 bytes = "1.0.1"
 derive-new = "0.5.8"
 getset = "0.1.0"
-net2 = "0.2.33"
+socket2 = "0.4.0"
 tokio = { version = "1.7.1", features = ["macros", "net", "rt-multi-thread"] }
 tokio-stream = "0.1.6"
 tokio-util = { version = "0.6.7", features = ["codec", "net"] }


### PR DESCRIPTION
The net2 crate is no longer maintained, and it is recommended to use
socket2 instead.

Fixes #13